### PR TITLE
Two sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,8 @@ A simple example of creating this service is as follows:
 
 ```rust
    use discv5::{enr, enr::{CombinedKey, NodeId}, TokioExecutor, Discv5, Discv5ConfigBuilder};
+   use discv5::socket::ListenConfig;
    use std::net::SocketAddr;
-
-   // listening address and port
-   let listen_addr = "0.0.0.0:9000".parse::<SocketAddr>().unwrap();
 
    // construct a local ENR
    let enr_key = CombinedKey::generate_secp256k1();
@@ -57,15 +55,21 @@ A simple example of creating this service is as follows:
    // default configuration
    let config = Discv5ConfigBuilder::new().build();
 
+   // configuration for the sockets to listen on
+   let listen_config = ListenConfig::Ipv4 {
+       ip: Ipv4Addr::UNSPECIFIED,
+       port: 9000,
+   };
+
    // construct the discv5 server
-   let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+   let mut discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
 
    // In order to bootstrap the routing table an external ENR should be added
    // This can be done via add_enr. I.e.:
    // discv5.add_enr(<ENR>)
 
    // start the discv5 server
-   runtime.block_on(discv5.start(listen_addr));
+   runtime.block_on(discv5.start());
 
    // run a find_node query
    runtime.block_on(async {

--- a/examples/custom_executor.rs
+++ b/examples/custom_executor.rs
@@ -9,8 +9,9 @@
 //! $ cargo run --example custom_executor <BASE64ENR>
 //! ```
 
-use discv5::socket::ListenConfig;
-use discv5::{enr, enr::CombinedKey, Discv5, Discv5ConfigBuilder, Discv5Event};
+use discv5::{
+    enr, enr::CombinedKey, socket::ListenConfig, Discv5, Discv5ConfigBuilder, Discv5Event,
+};
 use std::net::Ipv4Addr;
 
 fn main() {

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -105,17 +105,7 @@ async fn main() {
     // let config = Discv5ConfigBuilder::new().enable_packet_filter().build();
 
     // default configuration without packet filtering
-    let config = Discv5ConfigBuilder::new()
-        .ip_mode(match args.socket_kind {
-            SocketKind::Ip4 => discv5::IpMode::Ip4,
-            SocketKind::Ip6 => discv5::IpMode::Ip6 {
-                enable_mapped_addresses: false,
-            },
-            SocketKind::Ds => discv5::IpMode::Ip6 {
-                enable_mapped_addresses: true,
-            },
-        })
-        .build();
+    let config = Discv5ConfigBuilder::new().build();
 
     info!("Node Id: {}", enr.node_id());
     if args.enr_ip6.is_some() || args.enr_ip4.is_some() {

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -30,8 +30,7 @@ use tracing::{info, warn};
 
 #[derive(Parser)]
 struct FindNodesArgs {
-    /// Type of socket to bind ['ds', 'ip4', 'ip6']. The dual stack option will enable mapped
-    /// addresses over an IpV6 socket.
+    /// Type of socket to bind ['ds', 'ip4', 'ip6'].
     #[clap(long, default_value_t = SocketKind::Ds)]
     socket_kind: SocketKind,
     /// IpV4 to advertise in the ENR. This is needed so that other IpV4 nodes can connect to us.

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -16,6 +16,7 @@
 //! For a simple CLI discovery service see [discv5-cli](https://github.com/AgeManning/discv5-cli)
 
 use clap::Parser;
+use discv5::socket::ListenConfig;
 use discv5::{
     enr,
     enr::{k256, CombinedKey},
@@ -26,7 +27,6 @@ use std::{
     time::Duration,
 };
 use tracing::{info, warn};
-use discv5::socket::ListenConfig;
 
 #[derive(Parser)]
 struct FindNodesArgs {
@@ -72,16 +72,12 @@ async fn main() {
     let port = args
         .port
         .unwrap_or_else(|| (rand::random::<u16>() % 1000) + 9000);
-    let port6 = args
-        .port
-        .unwrap_or_else(|| {
-            loop {
-                let port6 = (rand::random::<u16>() % 1000) + 9000;
-                if port6 != port {
-                    return port6;
-                }
-            }
-        });
+    let port6 = args.port.unwrap_or_else(|| loop {
+        let port6 = (rand::random::<u16>() % 1000) + 9000;
+        if port6 != port {
+            return port6;
+        }
+    });
 
     let enr_key = if args.use_test_key {
         // A fixed key for testing
@@ -147,7 +143,7 @@ async fn main() {
             ipv4_port: port,
             ipv6: Ipv6Addr::UNSPECIFIED,
             ipv6_port: port6,
-        }
+        },
     };
 
     // construct the discv5 server

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -16,10 +16,10 @@
 //! For a simple CLI discovery service see [discv5-cli](https://github.com/AgeManning/discv5-cli)
 
 use clap::Parser;
-use discv5::socket::ListenConfig;
 use discv5::{
     enr,
     enr::{k256, CombinedKey},
+    socket::ListenConfig,
     Discv5, Discv5ConfigBuilder, Discv5Event,
 };
 use std::{

--- a/examples/request_enr.rs
+++ b/examples/request_enr.rs
@@ -13,9 +13,10 @@
 //!
 //! This requires the "libp2p" feature.
 #[cfg(feature = "libp2p")]
-use discv5::{enr, enr::CombinedKey, Discv5, Discv5Config};
+use discv5::socket::ListenConfig;
 #[cfg(feature = "libp2p")]
-use std::net::SocketAddr;
+use discv5::{enr, enr::CombinedKey, Discv5, Discv5Config};
+use std::net::Ipv4Addr;
 
 #[cfg(not(feature = "libp2p"))]
 fn main() {}
@@ -31,7 +32,10 @@ async fn main() {
         .try_init();
 
     // listening address and port
-    let listen_addr = "0.0.0.0:9000".parse::<SocketAddr>().unwrap();
+    let listen_config = ListenConfig::Ipv4 {
+        ip: Ipv4Addr::UNSPECIFIED,
+        port: 9000,
+    };
 
     // generate a new enr key
     let enr_key = CombinedKey::generate_secp256k1();
@@ -46,10 +50,10 @@ async fn main() {
         .expect("A multiaddr must be supplied");
 
     // construct the discv5 server
-    let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+    let mut discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
 
     // start the discv5 service
-    discv5.start(listen_addr).await.unwrap();
+    discv5.start().await.unwrap();
 
     // search for the ENR
     match discv5.request_enr(multiaddr).await {

--- a/examples/simple_server.rs
+++ b/examples/simple_server.rs
@@ -10,8 +10,9 @@
 //! $ cargo run --example simple_server -- <ENR-IP> <ENR-PORT> <BASE64ENR>
 //! ```
 
+use discv5::socket::ListenConfig;
 use discv5::{enr, enr::CombinedKey, Discv5, Discv5Config, Discv5Event};
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 
 #[tokio::main]
 async fn main() {
@@ -37,7 +38,10 @@ async fn main() {
     };
 
     // listening address and port
-    let listen_addr = "0.0.0.0:9000".parse::<SocketAddr>().unwrap();
+    let listen_config = ListenConfig::Ipv4 {
+        ip: Ipv4Addr::UNSPECIFIED,
+        port: 9000,
+    };
 
     let enr_key = CombinedKey::generate_secp256k1();
 
@@ -72,7 +76,7 @@ async fn main() {
     let config = Discv5Config::default();
 
     // construct the discv5 server
-    let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+    let mut discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
 
     // if we know of another peer's ENR, add it known peers
     if let Some(base64_enr) = std::env::args().nth(3) {
@@ -93,7 +97,7 @@ async fn main() {
     }
 
     // start the discv5 service
-    discv5.start(listen_addr).await.unwrap();
+    discv5.start().await.unwrap();
     println!("Server started");
 
     // get an event stream

--- a/examples/simple_server.rs
+++ b/examples/simple_server.rs
@@ -10,8 +10,7 @@
 //! $ cargo run --example simple_server -- <ENR-IP> <ENR-PORT> <BASE64ENR>
 //! ```
 
-use discv5::socket::ListenConfig;
-use discv5::{enr, enr::CombinedKey, Discv5, Discv5Config, Discv5Event};
+use discv5::{enr, enr::CombinedKey, socket::ListenConfig, Discv5, Discv5Config, Discv5Event};
 use std::net::Ipv4Addr;
 
 #[tokio::main]

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,13 +301,6 @@ impl Discv5ConfigBuilder {
         self
     }
 
-    /// Configures the type of socket to bind to. This also affects the selection of address to use
-    /// to contact an ENR.
-    // pub fn ip_mode(&mut self, ip_mode: IpMode) -> &mut Self {
-    //     self.config.ip_mode = ip_mode;
-    //     self
-    // }
-
     pub fn build(&mut self) -> Discv5Config {
         // If an executor is not provided, assume a current tokio runtime is running.
         if self.config.executor.is_none() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use crate::{
-    ipmode::IpMode, kbucket::MAX_NODES_PER_BUCKET, Enr, Executor, PermitBanList, RateLimiter,
-    RateLimiterBuilder,
+    kbucket::MAX_NODES_PER_BUCKET, Enr, Executor, PermitBanList, RateLimiter, RateLimiterBuilder,
 };
 ///! A set of configuration parameters to tune the discovery protocol.
 use std::time::Duration;
@@ -304,10 +303,10 @@ impl Discv5ConfigBuilder {
 
     /// Configures the type of socket to bind to. This also affects the selection of address to use
     /// to contact an ENR.
-    pub fn ip_mode(&mut self, ip_mode: IpMode) -> &mut Self {
-        self.config.ip_mode = ip_mode;
-        self
-    }
+    // pub fn ip_mode(&mut self, ip_mode: IpMode) -> &mut Self {
+    //     self.config.ip_mode = ip_mode;
+    //     self
+    // }
 
     pub fn build(&mut self) -> Discv5Config {
         // If an executor is not provided, assume a current tokio runtime is running.

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -37,8 +37,10 @@ use tracing::{debug, warn};
 use libp2p_core::Multiaddr;
 
 // Create lazy static variable for the global permit/ban list
-use crate::metrics::{Metrics, METRICS};
-use crate::socket::ListenConfig;
+use crate::{
+    metrics::{Metrics, METRICS},
+    socket::ListenConfig,
+};
 lazy_static! {
     pub static ref PERMIT_BAN_LIST: RwLock<crate::PermitBanList> =
         RwLock::new(crate::PermitBanList::default());

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 use enr::{CombinedKey, EnrError, EnrKey, NodeId};
 use parking_lot::RwLock;
-use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{
     future::Future,
     net::SocketAddr,
@@ -96,6 +95,7 @@ impl Discv5 {
         local_enr: Enr,
         enr_key: CombinedKey,
         mut config: Discv5Config,
+        listen_config: ListenConfig,
     ) -> Result<Self, &'static str> {
         // ensure the keypair matches the one that signed the enr.
         if local_enr.public_key() != enr_key.public() {
@@ -131,14 +131,6 @@ impl Discv5 {
 
         // Update the PermitBan list based on initial configuration
         *PERMIT_BAN_LIST.write() = config.permit_ban_list.clone();
-
-        // FIXME
-        let listen_config = ListenConfig::DualStack {
-            ipv4: Ipv4Addr::UNSPECIFIED,
-            ipv4_port: 9000,
-            ipv6: Ipv6Addr::UNSPECIFIED,
-            ipv6_port: 9006,
-        };
 
         let ip_mode = IpMode::new_from_listen_config(&listen_config);
 

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -20,10 +20,11 @@ use crate::{
     },
     node_info::NodeContact,
     service::{QueryKind, Service, ServiceRequest, TalkRequest},
-    Discv5Config, Enr,
+    Discv5Config, Enr, IpMode,
 };
 use enr::{CombinedKey, EnrError, EnrKey, NodeId};
 use parking_lot::RwLock;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{
     future::Future,
     net::SocketAddr,
@@ -38,6 +39,7 @@ use libp2p_core::Multiaddr;
 
 // Create lazy static variable for the global permit/ban list
 use crate::metrics::{Metrics, METRICS};
+use crate::socket::ListenConfig;
 lazy_static! {
     pub static ref PERMIT_BAN_LIST: RwLock<crate::PermitBanList> =
         RwLock::new(crate::PermitBanList::default());
@@ -83,6 +85,10 @@ pub struct Discv5 {
     local_enr: Arc<RwLock<Enr>>,
     /// The key associated with the local ENR, required for updating the local ENR.
     enr_key: Arc<RwLock<CombinedKey>>,
+    /// Type of socket to create.
+    listen_config: ListenConfig,
+    // Type of socket we are using
+    ip_mode: IpMode,
 }
 
 impl Discv5 {
@@ -126,6 +132,16 @@ impl Discv5 {
         // Update the PermitBan list based on initial configuration
         *PERMIT_BAN_LIST.write() = config.permit_ban_list.clone();
 
+        // FIXME
+        let listen_config = ListenConfig::DualStack {
+            ipv4: Ipv4Addr::UNSPECIFIED,
+            ipv4_port: 9000,
+            ipv6: Ipv6Addr::UNSPECIFIED,
+            ipv6_port: 9006,
+        };
+
+        let ip_mode = IpMode::new_from_listen_config(&listen_config);
+
         Ok(Discv5 {
             config,
             service_channel: None,
@@ -133,6 +149,8 @@ impl Discv5 {
             kbuckets,
             local_enr,
             enr_key,
+            listen_config,
+            ip_mode,
         })
     }
 
@@ -149,7 +167,7 @@ impl Discv5 {
             self.enr_key.clone(),
             self.kbuckets.clone(),
             self.config.clone(),
-            listen_socket,
+            self.listen_config.clone(),
         )
         .await?;
         self.service_exit = Some(service_exit);
@@ -178,7 +196,7 @@ impl Discv5 {
     /// them upfront.
     pub fn add_enr(&self, enr: Enr) -> Result<(), &'static str> {
         // only add ENR's that have a valid udp socket.
-        if self.config.ip_mode.get_contactable_addr(&enr).is_none() {
+        if self.ip_mode.get_contactable_addr(&enr).is_none() {
             warn!("ENR attempted to be added without an UDP socket compatible with configured IpMode has been ignored.");
             return Err("ENR has no compatible UDP socket to connect to");
         }
@@ -474,7 +492,7 @@ impl Discv5 {
 
         let (callback_send, callback_recv) = oneshot::channel();
         let channel = self.clone_channel();
-        let ip_mode = self.config.ip_mode;
+        let ip_mode = self.ip_mode;
 
         async move {
             let node_contact = NodeContact::try_from_enr(enr, ip_mode)?;

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -1,11 +1,12 @@
 #![cfg(test)]
 
-use crate::socket::ListenConfig;
-use crate::{Discv5, *};
+use crate::{socket::ListenConfig, Discv5, *};
 use enr::{k256, CombinedKey, Enr, EnrBuilder, EnrKey, NodeId};
 use rand_core::{RngCore, SeedableRng};
-use std::net::Ipv6Addr;
-use std::{collections::HashMap, net::Ipv4Addr};
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, Ipv6Addr},
+};
 
 fn init() {
     let _ = tracing_subscriber::fmt()

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -329,7 +329,7 @@ async fn test_discovery_three_peers_ipv4() {
     // Generate `num_nodes` + bootstrap_node and target_node keypairs from given seed
     let keypairs = generate_deterministic_keypair(total_nodes + 2, seed);
     // IPv4
-    let nodes = build_nodes_from_keypairs(keypairs, 11200).await;
+    let nodes = build_nodes_from_keypairs(keypairs, 10000).await;
 
     assert_eq!(
         total_nodes,
@@ -347,7 +347,7 @@ async fn test_discovery_three_peers_ipv6() {
     // Generate `num_nodes` + bootstrap_node and target_node keypairs from given seed
     let keypairs = generate_deterministic_keypair(total_nodes + 2, seed);
     // IPv6
-    let nodes = build_nodes_from_keypairs_ipv6(keypairs, 11200).await;
+    let nodes = build_nodes_from_keypairs_ipv6(keypairs, 10010).await;
 
     assert_eq!(
         total_nodes,
@@ -365,7 +365,7 @@ async fn test_discovery_three_peers_dual_stack() {
     // Generate `num_nodes` + bootstrap_node and target_node keypairs from given seed
     let keypairs = generate_deterministic_keypair(total_nodes + 2, seed);
     // DualStack
-    let nodes = build_nodes_from_keypairs_dual_stack(keypairs, 11200).await;
+    let nodes = build_nodes_from_keypairs_dual_stack(keypairs, 10020).await;
 
     assert_eq!(
         total_nodes,
@@ -386,15 +386,15 @@ async fn test_discovery_three_peers_mixed() {
 
     let mut nodes = vec![];
     // Bootstrap node (DualStack)
-    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 12000).await);
+    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 10030).await);
     // A node to run query (DualStack)
-    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 12010).await);
+    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 10031).await);
     // IPv4 node
-    nodes.append(&mut build_nodes_from_keypairs(vec![keypairs.remove(0)], 12020).await);
+    nodes.append(&mut build_nodes_from_keypairs(vec![keypairs.remove(0)], 10032).await);
     // IPv6 node
-    nodes.append(&mut build_nodes_from_keypairs_ipv6(vec![keypairs.remove(0)], 12030).await);
+    nodes.append(&mut build_nodes_from_keypairs_ipv6(vec![keypairs.remove(0)], 10033).await);
     // Target node (DualStack)
-    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 12040).await);
+    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 10034).await);
 
     assert!(keypairs.is_empty());
     assert_eq!(5, nodes.len());
@@ -417,15 +417,15 @@ async fn test_discovery_three_peers_mixed_query_from_ipv4() {
 
     let mut nodes = vec![];
     // Bootstrap node (DualStack)
-    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 12000).await);
+    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 10040).await);
     // A node to run query (** IPv4 **)
-    nodes.append(&mut build_nodes_from_keypairs(vec![keypairs.remove(0)], 12010).await);
+    nodes.append(&mut build_nodes_from_keypairs(vec![keypairs.remove(0)], 10041).await);
     // IPv4 node
-    nodes.append(&mut build_nodes_from_keypairs(vec![keypairs.remove(0)], 12020).await);
+    nodes.append(&mut build_nodes_from_keypairs(vec![keypairs.remove(0)], 10042).await);
     // IPv6 node
-    nodes.append(&mut build_nodes_from_keypairs_ipv6(vec![keypairs.remove(0)], 12030).await);
+    nodes.append(&mut build_nodes_from_keypairs_ipv6(vec![keypairs.remove(0)], 10043).await);
     // Target node (DualStack)
-    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 12040).await);
+    nodes.append(&mut build_nodes_from_keypairs_dual_stack(vec![keypairs.remove(0)], 10044).await);
 
     assert!(keypairs.is_empty());
     assert_eq!(5, nodes.len());

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -242,20 +242,16 @@ impl Handler {
 
         let mut listen_sockets = SmallVec::default();
         match listen_config {
-            ListenConfig::Ipv4 { ip, port } => {
-                listen_sockets.push(SocketAddr::V4(SocketAddrV4::new(ip, port)))
-            }
-            ListenConfig::Ipv6 { ip, port } => {
-                listen_sockets.push(SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0)))
-            }
+            ListenConfig::Ipv4 { ip, port } => listen_sockets.push((ip, port).into()),
+            ListenConfig::Ipv6 { ip, port } => listen_sockets.push((ip, port).into()),
             ListenConfig::DualStack {
                 ipv4,
                 ipv4_port,
                 ipv6,
                 ipv6_port,
             } => {
-                listen_sockets.push(SocketAddr::V4(SocketAddrV4::new(ipv4, ipv4_port)));
-                listen_sockets.push(SocketAddr::V6(SocketAddrV6::new(ipv6, ipv6_port, 0, 0)));
+                listen_sockets.push((ipv4, ipv4_port).into());
+                listen_sockets.push((ipv6, ipv6_port).into());
             }
         };
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -41,7 +41,6 @@ use enr::{CombinedKey, NodeId};
 use futures::prelude::*;
 use parking_lot::RwLock;
 use smallvec::SmallVec;
-use std::net::{SocketAddrV4, SocketAddrV6};
 use std::{
     collections::HashMap,
     convert::TryFrom,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -64,8 +64,7 @@ pub use crate::node_info::{NodeAddress, NodeContact};
 
 use crate::metrics::METRICS;
 
-use crate::lru_time_cache::LruTimeCache;
-use crate::socket::ListenConfig;
+use crate::{lru_time_cache::LruTimeCache, socket::ListenConfig};
 use active_requests::ActiveRequests;
 use request_call::RequestCall;
 use session::Session;

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -275,9 +275,9 @@ async fn test_self_request() {
     let config = Discv5ConfigBuilder::new().enable_packet_filter().build();
     let enr = EnrBuilder::new("v4")
         .ip4(Ipv4Addr::LOCALHOST)
-        .udp4(5000)
+        .udp4(5004)
         .ip6(Ipv6Addr::LOCALHOST)
-        .udp6(5001)
+        .udp6(5005)
         .build(&key)
         .unwrap();
 

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use crate::handler::HandlerOut::RequestFailed;
-use crate::RequestError::SelfRequest;
+use crate::{handler::HandlerOut::RequestFailed, RequestError::SelfRequest};
 use active_requests::ActiveRequests;
 use enr::EnrBuilder;
 use std::time::Duration;

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -50,8 +50,11 @@ async fn simple_session_message() {
     let (_exit_send, sender_send, _sender_recv) = Handler::spawn(
         arc_rw!(sender_enr.clone()),
         arc_rw!(key1),
-        sender_enr.udp4_socket().unwrap().into(),
         config.clone(),
+        ListenConfig::Ipv4 {
+            ip: sender_enr.ip4().unwrap(),
+            port: sender_enr.udp4().unwrap(),
+        },
     )
     .await
     .unwrap();
@@ -59,8 +62,11 @@ async fn simple_session_message() {
     let (_exit_recv, recv_send, mut receiver_recv) = Handler::spawn(
         arc_rw!(receiver_enr.clone()),
         arc_rw!(key2),
-        receiver_enr.udp4_socket().unwrap().into(),
         config,
+        ListenConfig::Ipv4 {
+            ip: receiver_enr.ip4().unwrap(),
+            port: receiver_enr.udp4().unwrap(),
+        },
     )
     .await
     .unwrap();
@@ -126,8 +132,11 @@ async fn multiple_messages() {
     let (_exit_send, sender_handler, mut sender_handler_recv) = Handler::spawn(
         arc_rw!(sender_enr.clone()),
         arc_rw!(key1),
-        sender_enr.udp4_socket().unwrap().into(),
         config.clone(),
+        ListenConfig::Ipv4 {
+            ip: sender_enr.ip4().unwrap(),
+            port: sender_enr.udp4().unwrap(),
+        },
     )
     .await
     .unwrap();
@@ -135,8 +144,11 @@ async fn multiple_messages() {
     let (_exit_recv, recv_send, mut receiver_handler) = Handler::spawn(
         arc_rw!(receiver_enr.clone()),
         arc_rw!(key2),
-        receiver_enr.udp4_socket().unwrap().into(),
         config,
+        ListenConfig::Ipv4 {
+            ip: receiver_enr.ip4().unwrap(),
+            port: receiver_enr.udp4().unwrap(),
+        },
     )
     .await
     .unwrap();

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -1,6 +1,8 @@
-use crate::socket::ListenConfig;
-use crate::Enr;
-use crate::IpMode::{DualStack, Ip4, Ip6};
+use crate::{
+    socket::ListenConfig,
+    Enr,
+    IpMode::{DualStack, Ip4, Ip6},
+};
 use std::net::SocketAddr;
 
 ///! A set of configuration parameters to tune the discovery protocol.
@@ -39,7 +41,7 @@ impl IpMode {
     /// dual stack, an Enr that advertises both an Ipv4 and a canonical Ipv6 address will be
     /// contacted using their Ipv6 address.
     pub fn get_contactable_addr(&self, enr: &Enr) -> Option<SocketAddr> {
-        // A function to get a cononical ipv6 address from an Enr
+        // A function to get a canonical ipv6 address from an Enr
 
         /// NOTE: There is nothing in the spec preventing compat/mapped addresses from being
         /// transmitted in the ENR. Here we choose to enforce canonical addresses since

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -14,7 +14,7 @@ pub enum IpMode {
     /// routing table if they contain a contactable IPv4 address.
     #[default]
     Ip4,
-    /// IPv4 only. This creates an IPv6 only UDP socket and will only store ENRs in the local
+    /// IPv6 only. This creates an IPv6 only UDP socket and will only store ENRs in the local
     /// routing table if they contain a contactable IPv6 address. Mapped addresses will be
     /// disabled.
     Ip6,

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -1,5 +1,8 @@
+use crate::socket::ListenConfig;
 use crate::Enr;
+use crate::IpMode::{DualStack, Ip4, Ip6};
 use std::net::SocketAddr;
+
 ///! A set of configuration parameters to tune the discovery protocol.
 
 /// Sets the socket type to be established and also determines the type of ENRs that we will store
@@ -20,6 +23,14 @@ pub enum IpMode {
 }
 
 impl IpMode {
+    pub(crate) fn new_from_listen_config(listen_config: &ListenConfig) -> Self {
+        match listen_config {
+            ListenConfig::Ipv4 { .. } => Ip4,
+            ListenConfig::Ipv6 { .. } => Ip6,
+            ListenConfig::DualStack { .. } => DualStack,
+        }
+    }
+
     pub fn is_ipv4(&self) -> bool {
         self == &IpMode::Ip4
     }

--- a/src/ipmode.rs
+++ b/src/ipmode.rs
@@ -32,7 +32,7 @@ impl IpMode {
     }
 
     pub fn is_ipv4(&self) -> bool {
-        self == &IpMode::Ip4
+        self == &Ip4
     }
 
     /// Get the contactable Socket address of an Enr under current configuration. When running in
@@ -56,9 +56,9 @@ impl IpMode {
         }
 
         match self {
-            IpMode::Ip4 => enr.udp4_socket().map(SocketAddr::V4),
-            IpMode::Ip6 => canonical_ipv6_enr_addr(enr).map(SocketAddr::V6),
-            IpMode::DualStack => {
+            Ip4 => enr.udp4_socket().map(SocketAddr::V4),
+            Ip6 => canonical_ipv6_enr_addr(enr).map(SocketAddr::V6),
+            DualStack => {
                 canonical_ipv6_enr_addr(enr)
                     .map(SocketAddr::V6)
                     // NOTE: general consensus is that ipv6 addresses should be preferred.
@@ -91,7 +91,7 @@ mod tests {
                 name,
                 enr_ip4: None,
                 enr_ip6: None,
-                ip_mode: IpMode::Ip4,
+                ip_mode: Ip4,
                 expected_socket_addr: None,
             }
         }
@@ -150,15 +150,15 @@ mod tests {
     fn empty_enr_no_contactable_address() {
         // Empty ENR
         TestCase::new("Empty enr is non contactable by ip4 node")
-            .ip_mode(IpMode::Ip4)
+            .ip_mode(Ip4)
             .test();
 
         TestCase::new("Empty enr is not contactable by ip6 only node")
-            .ip_mode(IpMode::Ip6)
+            .ip_mode(Ip6)
             .test();
 
         TestCase::new("Empty enr is not contactable by dual stack node")
-            .ip_mode(IpMode::DualStack)
+            .ip_mode(DualStack)
             .test();
     }
 
@@ -167,18 +167,18 @@ mod tests {
         // Ip4 only ENR
         TestCase::new("Ipv4 only enr is contactable by ip4 node")
             .enr_ip4(Ipv4Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip4)
+            .ip_mode(Ip4)
             .expect_ip4(Ipv4Addr::LOCALHOST)
             .test();
 
         TestCase::new("Ipv4 only enr is not contactable by ip6 only node")
             .enr_ip4(Ipv4Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip6)
+            .ip_mode(Ip6)
             .test();
 
         TestCase::new("Ipv4 only enr is contactable by dual stack node")
             .enr_ip4(Ipv4Addr::LOCALHOST)
-            .ip_mode(IpMode::DualStack)
+            .ip_mode(DualStack)
             .expect_ip4(Ipv4Addr::LOCALHOST)
             .test();
     }
@@ -188,18 +188,18 @@ mod tests {
         // Ip4 only ENR
         TestCase::new("Ipv6 only enr is not contactable by ip4 node")
             .enr_ip6(Ipv6Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip4)
+            .ip_mode(Ip4)
             .test();
 
         TestCase::new("Ipv6 only enr is contactable by ip6 only node")
             .enr_ip6(Ipv6Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip6)
+            .ip_mode(Ip6)
             .expect_ip6(Ipv6Addr::LOCALHOST)
             .test();
 
         TestCase::new("Ipv6 only enr is contactable by dual stack node")
             .enr_ip6(Ipv6Addr::LOCALHOST)
-            .ip_mode(IpMode::DualStack)
+            .ip_mode(DualStack)
             .expect_ip6(Ipv6Addr::LOCALHOST)
             .test();
     }
@@ -210,21 +210,21 @@ mod tests {
         TestCase::new("Dual stack enr is contactable by ip4 node")
             .enr_ip6(Ipv6Addr::LOCALHOST)
             .enr_ip4(Ipv4Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip4)
+            .ip_mode(Ip4)
             .expect_ip4(Ipv4Addr::LOCALHOST)
             .test();
 
         TestCase::new("Dual stack enr is contactable by ip6 only node")
             .enr_ip6(Ipv6Addr::LOCALHOST)
             .enr_ip4(Ipv4Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip6)
+            .ip_mode(Ip6)
             .expect_ip6(Ipv6Addr::LOCALHOST)
             .test();
 
         TestCase::new("Dual stack enr is contactable by dual stack node")
             .enr_ip6(Ipv6Addr::LOCALHOST)
             .enr_ip4(Ipv4Addr::LOCALHOST)
-            .ip_mode(IpMode::Ip6)
+            .ip_mode(Ip6)
             .expect_ip6(Ipv6Addr::LOCALHOST)
             .test();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,8 @@
 //!
 //! ```rust
 //!    use discv5::{enr, enr::{CombinedKey, NodeId}, TokioExecutor, Discv5, Discv5ConfigBuilder};
-//!    use std::net::SocketAddr;
-//!
-//!    // listening address and port
-//!    let listen_addr = "0.0.0.0:9000".parse::<SocketAddr>().unwrap();
+//!    use discv5::socket::ListenConfig;
+//!    use std::net::{Ipv4Addr, SocketAddr};
 //!
 //!    // construct a local ENR
 //!    let enr_key = CombinedKey::generate_secp256k1();
@@ -77,15 +75,21 @@
 //!    // default configuration
 //!    let config = Discv5ConfigBuilder::new().build();
 //!
+//!    // configuration for the sockets to listen on
+//!    let listen_config = ListenConfig::Ipv4 {
+//!        ip: Ipv4Addr::UNSPECIFIED,
+//!        port: 9000,
+//!    };
+//!
 //!    // construct the discv5 server
-//!    let mut discv5 = Discv5::new(enr, enr_key, config).unwrap();
+//!    let mut discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
 //!
 //!    // In order to bootstrap the routing table an external ENR should be added
 //!    // This can be done via add_enr. I.e.:
 //!    // discv5.add_enr(<ENR>)
 //!
 //!    // start the discv5 server
-//!    runtime.block_on(discv5.start(listen_addr));
+//!    runtime.block_on(discv5.start());
 //!
 //!    // run a find_node query
 //!    runtime.block_on(async {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -434,8 +434,13 @@ impl Message {
                         let mut ip = [0u8; 16];
                         ip.copy_from_slice(&ip_bytes);
                         let ipv6 = Ipv6Addr::from(ip);
-                        // If the ipv6 is ipv4 compatible/mapped, simply return the ipv4.
-                        if let Some(ipv4) = ipv6.to_ipv4() {
+
+                        if ipv6.is_loopback() {
+                            // Checking if loopback address since IPv6Addr::to_ipv4 returns
+                            // IPv4 address for IPv6 loopback address.
+                            IpAddr::V6(ipv6)
+                        } else if let Some(ipv4) = ipv6.to_ipv4() {
+                            // If the ipv6 is ipv4 compatible/mapped, simply return the ipv4.
                             IpAddr::V4(ipv4)
                         } else {
                             IpAddr::V6(ipv6)
@@ -605,6 +610,7 @@ impl Message {
 mod tests {
     use super::*;
     use enr::EnrBuilder;
+    use std::net::Ipv4Addr;
 
     #[test]
     fn ref_test_encode_request_ping() {
@@ -766,6 +772,50 @@ mod tests {
             body: ResponseBody::Pong {
                 enr_seq: 15,
                 ip: "127.0.0.1".parse().unwrap(),
+                port: 80,
+            },
+        });
+
+        let encoded = request.clone().encode();
+        let decoded = Message::decode(&encoded).unwrap();
+
+        assert_eq!(request, decoded);
+    }
+
+    #[test]
+    fn encode_decode_ping_response_ipv4_mapped() {
+        let id = RequestId(vec![1]);
+        let request = Message::Response(Response {
+            id: id.clone(),
+            body: ResponseBody::Pong {
+                enr_seq: 15,
+                ip: IpAddr::V6(Ipv4Addr::new(192, 0, 2, 1).to_ipv6_mapped()),
+                port: 80,
+            },
+        });
+
+        let encoded = request.encode();
+        let decoded = Message::decode(&encoded).unwrap();
+        let expected = Message::Response(Response {
+            id,
+            body: ResponseBody::Pong {
+                enr_seq: 15,
+                ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+                port: 80,
+            },
+        });
+
+        assert_eq!(expected, decoded);
+    }
+
+    #[test]
+    fn encode_decode_ping_response_ipv6_loopback() {
+        let id = RequestId(vec![1]);
+        let request = Message::Response(Response {
+            id,
+            body: ResponseBody::Pong {
+                enr_seq: 15,
+                ip: IpAddr::V6(Ipv6Addr::LOCALHOST),
                 port: 80,
             },
         });

--- a/src/service.rs
+++ b/src/service.rs
@@ -151,8 +151,7 @@ pub enum ServiceRequest {
     RequestEventStream(oneshot::Sender<mpsc::Receiver<Discv5Event>>),
 }
 
-use crate::discv5::PERMIT_BAN_LIST;
-use crate::socket::ListenConfig;
+use crate::{discv5::PERMIT_BAN_LIST, socket::ListenConfig};
 
 pub struct Service {
     /// Configuration parameters.

--- a/src/service.rs
+++ b/src/service.rs
@@ -152,6 +152,7 @@ pub enum ServiceRequest {
 }
 
 use crate::discv5::PERMIT_BAN_LIST;
+use crate::socket::ListenConfig;
 
 pub struct Service {
     /// Configuration parameters.
@@ -253,7 +254,7 @@ impl Service {
         enr_key: Arc<RwLock<CombinedKey>>,
         kbuckets: Arc<RwLock<KBucketsTable<NodeId, Enr>>>,
         config: Discv5Config,
-        listen_socket: SocketAddr,
+        listen_config: ListenConfig,
     ) -> Result<(oneshot::Sender<()>, mpsc::Sender<ServiceRequest>), std::io::Error> {
         // process behaviour-level configuration parameters
         let ip_votes = if config.enr_update {
@@ -265,12 +266,14 @@ impl Service {
             None
         };
 
+        let ip_mode = IpMode::new_from_listen_config(&listen_config);
+
         // build the session service
         let (handler_exit, handler_send, handler_recv) = Handler::spawn(
             local_enr.clone(),
             enr_key.clone(),
-            listen_socket,
             config.clone(),
+            listen_config,
         )
         .await?;
 
@@ -299,6 +302,7 @@ impl Service {
                     event_stream: None,
                     exit,
                     config: config.clone(),
+                    ip_mode,
                 };
 
                 info!("Discv5 Service started");

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -10,6 +10,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot};
 
 mod filter;
@@ -95,35 +96,43 @@ impl Socket {
             local_node_id,
         } = config;
 
-        // For now intentionally forgettig which socket is the ipv4 and which is the ipv6 one.
-        let (first_addr, maybe_second_addr): (SocketAddr, Option<_>) = match listen_config {
-            ListenConfig::Ipv4 { ip, port } => ((ip, port).into(), None),
-            ListenConfig::Ipv6 { ip, port } => ((ip, port).into(), None),
+        // For recv socket, intentionally forgetting which socket is the ipv4 and which is the ipv6 one.
+        let (first_recv, second_recv, send_ipv4, send_ipv6): (
+            Arc<UdpSocket>,
+            Option<_>,
+            Option<_>,
+            Option<_>,
+        ) = match listen_config {
+            ListenConfig::Ipv4 { ip, port } => {
+                let ipv4_socket = Arc::new(Socket::new_socket(&(ip, port).into()).await?);
+                (ipv4_socket.clone(), None, Some(ipv4_socket), None)
+            }
+            ListenConfig::Ipv6 { ip, port } => {
+                let ipv6_socket = Arc::new(Socket::new_socket(&(ip, port).into()).await?);
+                (ipv6_socket.clone(), None, None, Some(ipv6_socket))
+            }
             ListenConfig::DualStack {
                 ipv4,
                 ipv4_port,
                 ipv6,
                 ipv6_port,
-            } => ((ipv4, ipv4_port).into(), Some((ipv6, ipv6_port))),
+            } => {
+                let ipv4_socket = Arc::new(Socket::new_socket(&(ipv4, ipv4_port).into()).await?);
+                let ipv6_socket = Arc::new(Socket::new_socket(&(ipv6, ipv6_port).into()).await?);
+                (
+                    ipv4_socket.clone(),
+                    Some(ipv6_socket.clone()),
+                    Some(ipv4_socket),
+                    Some(ipv6_socket),
+                )
+            }
         };
-        let first_socket = Socket::new_socket(&first_addr).await?;
-        let maybe_second_socket = match maybe_second_addr {
-            Some(second_addr) => Some(Socket::new_socket(&second_addr.into()).await?),
-            None => None,
-        };
-
-        // Arc the udp socket for the send/recv tasks.
-        let recv_udp = Arc::new(first_socket);
-        let send_udp = recv_udp.clone();
-
-        let second_recv = maybe_second_socket.map(Arc::new);
-        let second_send = second_recv.clone();
 
         // spawn the recv handler
         let recv_config = RecvHandlerConfig {
             filter_config,
             executor: executor.clone(),
-            recv: recv_udp,
+            recv: first_recv,
             second_recv,
             local_node_id,
             expected_responses,
@@ -132,7 +141,7 @@ impl Socket {
 
         let (recv, recv_exit) = RecvHandler::spawn(recv_config);
         // spawn the sender handler
-        let (send, sender_exit) = SendHandler::spawn(executor, send_udp, second_send);
+        let (send, sender_exit) = SendHandler::spawn(executor, send_ipv4, send_ipv6);
 
         Ok(Socket {
             send,

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -10,8 +10,10 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    net::UdpSocket,
+    sync::{mpsc, oneshot},
+};
 
 mod filter;
 mod recv;
@@ -70,15 +72,15 @@ pub struct Socket {
 impl Socket {
     /// This creates and binds a new UDP socket.
     // In general this function can be expanded to handle more advanced socket creation.
-    async fn new_socket(socket_addr: &SocketAddr) -> Result<tokio::net::UdpSocket, Error> {
+    async fn new_socket(socket_addr: &SocketAddr) -> Result<UdpSocket, Error> {
         match socket_addr {
-            SocketAddr::V4(ip4) => tokio::net::UdpSocket::bind(ip4).await,
+            SocketAddr::V4(ip4) => UdpSocket::bind(ip4).await,
             SocketAddr::V6(ip6) => {
                 let socket = Socket2::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
                 socket.set_only_v6(true)?;
                 socket.set_nonblocking(true)?;
                 socket.bind(&SocketAddr::V6(*ip6).into())?;
-                tokio::net::UdpSocket::from_std(socket.into())
+                UdpSocket::from_std(socket.into())
             }
         }
     }

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -88,7 +88,6 @@ impl Socket {
     pub(crate) async fn new(config: SocketConfig) -> Result<Self, Error> {
         let SocketConfig {
             executor,
-            // socket_addr,
             filter_config,
             listen_config,
             ban_duration,

--- a/src/socket/recv.rs
+++ b/src/socket/recv.rs
@@ -48,7 +48,7 @@ pub struct RecvHandlerConfig {
 pub(crate) struct RecvHandler {
     /// The UDP recv socket.
     recv: Arc<UdpSocket>,
-    /// An option second UDO socket. Used when dialing over both Ipv4 and Ipv6.
+    /// An option second UDP socket. Used when dialing over both Ipv4 and Ipv6.
     second_recv: Option<Arc<UdpSocket>>,
     /// Simple hack to alternate reading from the first or the second socket.
     /// The list of waiting responses. These are used to allow incoming packets from sources

--- a/src/socket/recv.rs
+++ b/src/socket/recv.rs
@@ -3,16 +3,9 @@
 //! Every UDP packet passes a filter before being processed.
 
 use super::filter::{Filter, FilterConfig};
-use crate::{
-    ipmode::to_ipv4_mapped, metrics::METRICS, node_info::NodeAddress, packet::*, Executor,
-};
+use crate::{metrics::METRICS, node_info::NodeAddress, packet::*, Executor};
 use parking_lot::RwLock;
-use std::{
-    collections::HashMap,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{
     net::UdpSocket,
     sync::{mpsc, oneshot},
@@ -139,22 +132,10 @@ impl RecvHandler {
     /// handler.
     async fn handle_inbound(
         &mut self,
-        mut src_address: SocketAddr,
+        src_address: SocketAddr,
         length: usize,
         recv_buffer: &[u8; MAX_PACKET_SIZE],
     ) {
-        // Make sure ip4 addresses in dual stack nodes are reported correctly
-        if let IpAddr::V6(ip6) = src_address.ip() {
-            // NOTE: here we don't want to use the `to_ipv4` method, since it also includes compat
-            // addresses, which are deprecated. Dual stack nodes will report ipv4 addresses as
-            // mapped addresses and not compat, so this is not needed. This also messes with some
-            // valid ipv6 local addresses (for example, the ipv6 loopback address). Ideally what we
-            // want is `to_canonical`.
-            if let Some(ip4) = to_ipv4_mapped(&ip6) {
-                trace!("Mapping inbound packet addr from {} to {}", ip6, ip4);
-                src_address.set_ip(ip4.into())
-            }
-        }
         // Permit all expected responses
         let permitted = self.expected_responses.read().get(&src_address).is_some();
 

--- a/src/socket/send.rs
+++ b/src/socket/send.rs
@@ -1,5 +1,6 @@
 //! This is a standalone task that encodes and sends Discv5 UDP packets
 use crate::{metrics::METRICS, node_info::NodeAddress, packet::*, Executor};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::{
     net::UdpSocket,
@@ -16,8 +17,10 @@ pub struct OutboundPacket {
 
 /// The main task that handles outbound UDP packets.
 pub(crate) struct SendHandler {
-    /// The UDP send socket.
-    send: Arc<UdpSocket>,
+    /// The UDP send socket for IPv4.
+    send_ipv4: Option<Arc<UdpSocket>>,
+    /// The UDP send socket for IPv6.
+    send_ipv6: Option<Arc<UdpSocket>>,
     /// The channel to respond to send requests.
     handler_recv: mpsc::Receiver<OutboundPacket>,
     /// Exit channel to shutdown the handler.
@@ -30,14 +33,15 @@ impl SendHandler {
     /// shutdown the handler.
     pub(crate) fn spawn(
         executor: Box<dyn Executor>,
-        send: Arc<UdpSocket>,
-        second_send: Option<Arc<UdpSocket>>,
+        send_ipv4: Option<Arc<UdpSocket>>,
+        send_ipv6: Option<Arc<UdpSocket>>,
     ) -> (mpsc::Sender<OutboundPacket>, oneshot::Sender<()>) {
         let (exit_send, exit) = oneshot::channel();
         let (handler_send, handler_recv) = mpsc::channel(30);
 
         let mut send_handler = SendHandler {
-            send,
+            send_ipv4,
+            send_ipv6,
             handler_recv,
             exit,
         };
@@ -59,7 +63,7 @@ impl SendHandler {
                     if encoded_packet.len() > MAX_PACKET_SIZE {
                         warn!("Sending packet larger than max size: {} max: {}", encoded_packet.len(), MAX_PACKET_SIZE);
                     }
-                    if let Err(e) = self.send.send_to(&encoded_packet, &packet.node_address.socket_addr).await {
+                    if let Err(e) = self.send(&encoded_packet, &packet.node_address.socket_addr).await {
                         trace!("Could not send packet. Error: {:?}", e);
                     } else {
                         METRICS.add_sent_bytes(encoded_packet.len());
@@ -71,5 +75,33 @@ impl SendHandler {
                 }
             }
         }
+    }
+
+    async fn send(
+        &self,
+        encoded_packet: &Vec<u8>,
+        socket_addr: &SocketAddr,
+    ) -> Result<usize, String> {
+        let socket = match socket_addr {
+            SocketAddr::V4(_) => {
+                if let Some(socket) = self.send_ipv4.as_ref() {
+                    socket
+                } else {
+                    return Err("No IPv4 socket.".to_string());
+                }
+            }
+            SocketAddr::V6(_) => {
+                if let Some(socket) = self.send_ipv6.as_ref() {
+                    socket
+                } else {
+                    return Err("No IPv6 socket.".to_string());
+                }
+            }
+        };
+
+        socket
+            .send_to(encoded_packet, socket_addr)
+            .await
+            .map_err(|e| e.to_string())
     }
 }

--- a/src/socket/send.rs
+++ b/src/socket/send.rs
@@ -1,7 +1,6 @@
 //! This is a standalone task that encodes and sends Discv5 UDP packets
 use crate::{metrics::METRICS, node_info::NodeAddress, packet::*, Executor};
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 use tokio::{
     net::UdpSocket,
     sync::{mpsc, oneshot},


### PR DESCRIPTION
https://github.com/sigp/discv5/pull/160

## Breaking changes 

- `Discv5::new()` now takes a `ListenConfig` parameter for the sockets to listen on.
-  Removed the `listen_socket` parameter from `Discv5::start()`.
- `Discv5ConfigBuilder::ip_mode()` has been removed. `IpMode` would be determined internally according to the `ListenConfig` parameter passed to `Discv5::new()`.


## Changes in examples

- find_nodes
  - Added `--port6`

