### PR TITLE
Skip some tests if IPv6 is not supported

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { version = "1.15.0", features = ["full"] }
 rand_xorshift = "0.3.0"
 rand_core = "0.6.3"
 clap = { version = "3.1", features = ["derive"] }
+if-addrs = "0.10.1"
 
 [features]
 libp2p = ["libp2p-core"]

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -149,6 +149,23 @@ fn get_distance(node1: NodeId, node2: NodeId) -> Option<u64> {
     node1.log2_distance(&node2.into())
 }
 
+macro_rules! return_if_ipv6_is_not_supported {
+    () => {
+        let mut is_ipv6_supported = false;
+        for i in if_addrs::get_if_addrs().expect("network interfaces").iter() {
+            if !i.is_loopback() && i.addr.ip().is_ipv6() {
+                is_ipv6_supported = true;
+                break;
+            }
+        }
+
+        if !is_ipv6_supported {
+            tracing::error!("Seems Ipv6 is not supported. Test won't be run.");
+            return;
+        }
+    };
+}
+
 // Simple searching function to find seeds that give node ids for a range of testing and different
 // topologies
 #[allow(dead_code)]
@@ -334,6 +351,8 @@ async fn test_discovery_three_peers_ipv4() {
 /// Test for running a simple query test for a topology consisting of IPv6 nodes.
 #[tokio::test]
 async fn test_discovery_three_peers_ipv6() {
+    return_if_ipv6_is_not_supported!();
+
     init();
     let total_nodes = 3;
     // Seed is chosen such that all nodes are in the 256th bucket of bootstrap
@@ -352,6 +371,8 @@ async fn test_discovery_three_peers_ipv6() {
 /// Test for running a simple query test for a topology consisting of dual stack nodes.
 #[tokio::test]
 async fn test_discovery_three_peers_dual_stack() {
+    return_if_ipv6_is_not_supported!();
+
     init();
     let total_nodes = 3;
     // Seed is chosen such that all nodes are in the 256th bucket of bootstrap
@@ -371,6 +392,8 @@ async fn test_discovery_three_peers_dual_stack() {
 /// The node to run the query is DualStack.
 #[tokio::test]
 async fn test_discovery_three_peers_mixed() {
+    return_if_ipv6_is_not_supported!();
+
     init();
     let total_nodes = 3;
     // Seed is chosen such that all nodes are in the 256th bucket of bootstrap
@@ -402,6 +425,8 @@ async fn test_discovery_three_peers_mixed() {
 /// The node to run the query is IPv4.
 #[tokio::test]
 async fn test_discovery_three_peers_mixed_query_from_ipv4() {
+    return_if_ipv6_is_not_supported!();
+
     init();
     let total_nodes = 3;
     // Seed is chosen such that all nodes are in the 256th bucket of bootstrap

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -424,6 +424,9 @@ async fn test_discovery_three_peers_mixed() {
 
 /// Test for running a simple query test for a mixed topology of IPv4, IPv6 and dual stack nodes.
 /// The node to run the query is IPv4.
+// NOTE: This test emits the error log below because the node to run a query is in IPv4 mode so
+// IPv6 address included in the response is non-contactable.
+// `ERROR discv5::service: Query 0 has a non contactable enr: ENR: NodeId: 0xe030..dcbe, IpV4 Socket: None IpV6 Socket: Some([::1]:10043)`
 #[tokio::test]
 async fn test_discovery_three_peers_mixed_query_from_ipv4() {
     return_if_ipv6_is_not_supported!();

--- a/src/discv5/test.rs
+++ b/src/discv5/test.rs
@@ -149,6 +149,7 @@ fn get_distance(node1: NodeId, node2: NodeId) -> Option<u64> {
     node1.log2_distance(&node2.into())
 }
 
+#[macro_export]
 macro_rules! return_if_ipv6_is_not_supported {
     () => {
         let mut is_ipv6_supported = false;

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::{
     packet::DefaultProtocolId,
+    return_if_ipv6_is_not_supported,
     rpc::{Request, Response},
     Discv5ConfigBuilder, IpMode,
 };
@@ -270,7 +271,7 @@ async fn test_active_requests_insert() {
 }
 
 #[tokio::test]
-async fn test_self_request() {
+async fn test_self_request_ipv4() {
     init();
 
     let key = CombinedKey::generate_secp256k1();
@@ -278,8 +279,6 @@ async fn test_self_request() {
     let enr = EnrBuilder::new("v4")
         .ip4(Ipv4Addr::LOCALHOST)
         .udp4(5004)
-        .ip6(Ipv6Addr::LOCALHOST)
-        .udp6(5005)
         .build(&key)
         .unwrap();
 
@@ -287,11 +286,9 @@ async fn test_self_request() {
         arc_rw!(enr.clone()),
         arc_rw!(key),
         config,
-        ListenConfig::DualStack {
-            ipv4: enr.ip4().unwrap(),
-            ipv4_port: enr.udp4().unwrap(),
-            ipv6: enr.ip6().unwrap(),
-            ipv6_port: enr.udp6().unwrap(),
+        ListenConfig::Ipv4 {
+            ip: enr.ip4().unwrap(),
+            port: enr.udp4().unwrap(),
         },
     )
     .await
@@ -310,6 +307,33 @@ async fn test_self_request() {
         Some(RequestFailed(RequestId(vec![1]), SelfRequest)),
         handler_out
     );
+}
+
+#[tokio::test]
+async fn test_self_request_ipv6() {
+    return_if_ipv6_is_not_supported!();
+
+    init();
+
+    let key = CombinedKey::generate_secp256k1();
+    let config = Discv5ConfigBuilder::new().enable_packet_filter().build();
+    let enr = EnrBuilder::new("v4")
+        .ip6(Ipv6Addr::LOCALHOST)
+        .udp6(5005)
+        .build(&key)
+        .unwrap();
+
+    let (_exit_send, send, mut recv) = Handler::spawn::<DefaultProtocolId>(
+        arc_rw!(enr.clone()),
+        arc_rw!(key),
+        config,
+        ListenConfig::Ipv6 {
+            ip: enr.ip6().unwrap(),
+            port: enr.udp6().unwrap(),
+        },
+    )
+    .await
+    .unwrap();
 
     // self request (IPv6)
     let _ = send.send(HandlerIn::Request(

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -283,7 +283,7 @@ async fn test_self_request() {
         .build(&key)
         .unwrap();
 
-    let spawn_result = Handler::spawn::<DefaultProtocolId>(
+    let (_exit_send, send, mut recv) = Handler::spawn::<DefaultProtocolId>(
         arc_rw!(enr.clone()),
         arc_rw!(key),
         config,
@@ -294,16 +294,7 @@ async fn test_self_request() {
             ipv6_port: enr.udp6().unwrap(),
         },
     )
-    .await;
-
-    let (_exit_send, send, mut recv) = match spawn_result {
-        ok @ Ok(_) => ok,
-        Err(e) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
-            tracing::error!("AddrNotAvailable error identified, this likely means Ipv6 is not supported. Test won't be run");
-            return;
-        },
-        e @ Err(_) => e
-    }
+    .await
     .unwrap();
 
     // self request (IPv4)

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -105,14 +105,14 @@ async fn test_updating_connection_on_ping() {
     let ip = "127.0.0.1".parse().unwrap();
     let enr = EnrBuilder::new("v4")
         .ip4(ip)
-        .udp4(10011)
+        .udp4(10001)
         .build(&enr_key1)
         .unwrap();
     let ip2 = "127.0.0.1".parse().unwrap();
     let enr_key2 = CombinedKey::generate_secp256k1();
     let enr2 = EnrBuilder::new("v4")
         .ip4(ip2)
-        .udp4(10012)
+        .udp4(10002)
         .build(&enr_key2)
         .unwrap();
 

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -72,7 +72,7 @@ pub struct Socket {
 impl Socket {
     /// This creates and binds a new UDP socket.
     // In general this function can be expanded to handle more advanced socket creation.
-    pub(crate) async fn new_socket(socket_addr: &SocketAddr) -> Result<UdpSocket, Error> {
+    async fn new_socket(socket_addr: &SocketAddr) -> Result<UdpSocket, Error> {
         match socket_addr {
             SocketAddr::V4(ip4) => UdpSocket::bind(ip4).await,
             SocketAddr::V6(ip6) => {


### PR DESCRIPTION
I have checked that the tests which use IPv6 addresses have been skipped on GitHub Actions, and the tests run successfully on my laptop (IPv6 supported). 👌 

- discv5::test::test_discovery_three_peers_ipv6 
- discv5::test::test_discovery_three_peers_dual_stack
- discv5::test::test_discovery_three_peers_mixed
- discv5::test::test_discovery_three_peers_mixed_query_from_ipv4
- handler::tests::test_self_request_ipv6