### PR TITLE
Put ListenConfig inside Discv5Config

### DIFF
--- a/examples/custom_executor.rs
+++ b/examples/custom_executor.rs
@@ -41,10 +41,10 @@ fn main() {
         .unwrap();
 
     // default configuration - uses the current executor
-    let config = Discv5ConfigBuilder::new().build();
+    let config = Discv5ConfigBuilder::new(listen_config).build();
 
     // construct the discv5 server
-    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
+    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 
     // if we know of another peer's ENR, add it known peers
     if let Some(base64_enr) = std::env::args().nth(1) {

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -133,7 +133,7 @@ async fn main() {
     // let config = Discv5ConfigBuilder::new(listen_config).enable_packet_filter().build();
 
     // default configuration without packet filtering
-    let config = Discv5ConfigBuilder::new(listen_config.clone()).build();
+    let config = Discv5ConfigBuilder::new(listen_config).build();
 
     info!("Node Id: {}", enr.node_id());
     if args.enr_ip6.is_some() || args.enr_ip4.is_some() {
@@ -147,7 +147,7 @@ async fn main() {
     }
 
     // construct the discv5 server
-    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
+    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 
     // if we know of another peer's ENR, add it known peers
     for enr in args.remote_peer {

--- a/examples/find_nodes.rs
+++ b/examples/find_nodes.rs
@@ -111,22 +111,6 @@ async fn main() {
         builder.build(&enr_key).unwrap()
     };
 
-    // default configuration with packet filtering
-    // let config = Discv5ConfigBuilder::new().enable_packet_filter().build();
-
-    // default configuration without packet filtering
-    let config = Discv5ConfigBuilder::new().build();
-
-    info!("Node Id: {}", enr.node_id());
-    if args.enr_ip6.is_some() || args.enr_ip4.is_some() {
-        // if the ENR is useful print it
-        info!("Base64 ENR: {}", enr.to_base64());
-        info!(
-            "Local ENR IpV6 socket: {:?}. Local ENR IpV4 socket: {:?}",
-            enr.udp6_socket(),
-            enr.udp4_socket()
-        );
-    }
     // the address to listen on.
     let listen_config = match args.socket_kind {
         SocketKind::Ip4 => ListenConfig::Ipv4 {
@@ -144,6 +128,23 @@ async fn main() {
             ipv6_port: port6,
         },
     };
+
+    // default configuration with packet filtering
+    // let config = Discv5ConfigBuilder::new(listen_config).enable_packet_filter().build();
+
+    // default configuration without packet filtering
+    let config = Discv5ConfigBuilder::new(listen_config.clone()).build();
+
+    info!("Node Id: {}", enr.node_id());
+    if args.enr_ip6.is_some() || args.enr_ip4.is_some() {
+        // if the ENR is useful print it
+        info!("Base64 ENR: {}", enr.to_base64());
+        info!(
+            "Local ENR IpV6 socket: {:?}. Local ENR IpV4 socket: {:?}",
+            enr.udp6_socket(),
+            enr.udp4_socket()
+        );
+    }
 
     // construct the discv5 server
     let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();

--- a/examples/request_enr.rs
+++ b/examples/request_enr.rs
@@ -14,10 +14,10 @@
 //! This requires the "libp2p" feature.
 #[cfg(feature = "libp2p")]
 use discv5::socket::ListenConfig;
+use discv5::Discv5ConfigBuilder;
 #[cfg(feature = "libp2p")]
 use discv5::{enr, enr::CombinedKey, Discv5, Discv5Config};
 use std::net::Ipv4Addr;
-use discv5::Discv5ConfigBuilder;
 
 #[cfg(not(feature = "libp2p"))]
 fn main() {}

--- a/examples/request_enr.rs
+++ b/examples/request_enr.rs
@@ -17,6 +17,7 @@ use discv5::socket::ListenConfig;
 #[cfg(feature = "libp2p")]
 use discv5::{enr, enr::CombinedKey, Discv5, Discv5Config};
 use std::net::Ipv4Addr;
+use discv5::Discv5ConfigBuilder;
 
 #[cfg(not(feature = "libp2p"))]
 fn main() {}
@@ -43,14 +44,14 @@ async fn main() {
     let enr = enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
 
     // default discv5 configuration
-    let config = Discv5Config::default();
+    let config = Discv5ConfigBuilder::new(listen_config).build();
 
     let multiaddr = std::env::args()
         .nth(1)
         .expect("A multiaddr must be supplied");
 
     // construct the discv5 server
-    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
+    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 
     // start the discv5 service
     discv5.start().await.unwrap();

--- a/examples/simple_server.rs
+++ b/examples/simple_server.rs
@@ -10,7 +10,9 @@
 //! $ cargo run --example simple_server -- <ENR-IP> <ENR-PORT> <BASE64ENR>
 //! ```
 
-use discv5::{enr, enr::CombinedKey, socket::ListenConfig, Discv5, Discv5Config, Discv5Event};
+use discv5::{
+    enr, enr::CombinedKey, socket::ListenConfig, Discv5, Discv5ConfigBuilder, Discv5Event,
+};
 use std::net::Ipv4Addr;
 
 #[tokio::main]
@@ -72,10 +74,10 @@ async fn main() {
     }
 
     // default configuration
-    let config = Discv5Config::default();
+    let config = Discv5ConfigBuilder::new(listen_config).build();
 
     // construct the discv5 server
-    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
+    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 
     // if we know of another peer's ENR, add it known peers
     if let Some(base64_enr) = std::env::args().nth(3) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
+use crate::socket::ListenConfig;
 use crate::{
     kbucket::MAX_NODES_PER_BUCKET, Enr, Executor, PermitBanList, RateLimiter, RateLimiterBuilder,
 };
 ///! A set of configuration parameters to tune the discovery protocol.
 use std::time::Duration;
-use crate::socket::ListenConfig;
 
 /// Configuration parameters that define the performance of the discovery network.
 #[derive(Clone)]
@@ -145,9 +145,7 @@ impl Discv5ConfigBuilder {
             listen_config,
         };
 
-        Discv5ConfigBuilder {
-            config,
-        }
+        Discv5ConfigBuilder { config }
     }
 
     /// Whether to enable the incoming packet filter.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
-use crate::socket::ListenConfig;
 use crate::{
-    kbucket::MAX_NODES_PER_BUCKET, Enr, Executor, PermitBanList, RateLimiter, RateLimiterBuilder,
+    kbucket::MAX_NODES_PER_BUCKET, socket::ListenConfig, Enr, Executor, PermitBanList, RateLimiter,
+    RateLimiterBuilder,
 };
 ///! A set of configuration parameters to tune the discovery protocol.
 use std::time::Duration;

--- a/src/discv5.rs
+++ b/src/discv5.rs
@@ -39,10 +39,7 @@ use tracing::{debug, warn};
 use libp2p_core::Multiaddr;
 
 // Create lazy static variable for the global permit/ban list
-use crate::{
-    metrics::{Metrics, METRICS},
-    socket::ListenConfig,
-};
+use crate::metrics::{Metrics, METRICS};
 lazy_static! {
     pub static ref PERMIT_BAN_LIST: RwLock<crate::PermitBanList> =
         RwLock::new(crate::PermitBanList::default());
@@ -91,8 +88,6 @@ where
     local_enr: Arc<RwLock<Enr>>,
     /// The key associated with the local ENR, required for updating the local ENR.
     enr_key: Arc<RwLock<CombinedKey>>,
-    /// Type of socket to create.
-    listen_config: ListenConfig,
     // Type of socket we are using
     ip_mode: IpMode,
     /// Phantom for the protocol id.
@@ -104,7 +99,6 @@ impl<P: ProtocolIdentity> Discv5<P> {
         local_enr: Enr,
         enr_key: CombinedKey,
         mut config: Discv5Config,
-        listen_config: ListenConfig,
     ) -> Result<Self, &'static str> {
         // ensure the keypair matches the one that signed the enr.
         if local_enr.public_key() != enr_key.public() {
@@ -141,7 +135,7 @@ impl<P: ProtocolIdentity> Discv5<P> {
         // Update the PermitBan list based on initial configuration
         *PERMIT_BAN_LIST.write() = config.permit_ban_list.clone();
 
-        let ip_mode = IpMode::new_from_listen_config(&listen_config);
+        let ip_mode = IpMode::new_from_listen_config(&config.listen_config);
 
         Ok(Discv5 {
             config,
@@ -150,7 +144,6 @@ impl<P: ProtocolIdentity> Discv5<P> {
             kbuckets,
             local_enr,
             enr_key,
-            listen_config,
             ip_mode,
             _phantom: Default::default(),
         })
@@ -169,7 +162,6 @@ impl<P: ProtocolIdentity> Discv5<P> {
             self.enr_key.clone(),
             self.kbuckets.clone(),
             self.config.clone(),
-            self.listen_config.clone(),
         )
         .await?;
         self.service_exit = Some(service_exit);

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -215,7 +215,6 @@ impl Handler {
         enr: Arc<RwLock<Enr>>,
         key: Arc<RwLock<CombinedKey>>,
         config: Discv5Config,
-        listen_config: ListenConfig,
     ) -> Result<HandlerReturn, std::io::Error> {
         let (exit_sender, exit) = oneshot::channel();
         // create the channels to send/receive messages from the application
@@ -239,7 +238,7 @@ impl Handler {
         };
 
         let mut listen_sockets = SmallVec::default();
-        match listen_config {
+        match config.listen_config {
             ListenConfig::Ipv4 { ip, port } => listen_sockets.push((ip, port).into()),
             ListenConfig::Ipv6 { ip, port } => listen_sockets.push((ip, port).into()),
             ListenConfig::DualStack {
@@ -256,7 +255,7 @@ impl Handler {
         let socket_config = socket::SocketConfig {
             executor: config.executor.clone().expect("Executor must exist"),
             filter_config,
-            listen_config,
+            listen_config: config.listen_config.clone(),
             local_node_id: node_id,
             expected_responses: filter_expected_responses.clone(),
             ban_duration: config.ban_duration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,17 +72,17 @@
 //!        .build()
 //!        .unwrap();
 //!
-//!    // default configuration
-//!    let config = Discv5ConfigBuilder::new().build();
-//!
 //!    // configuration for the sockets to listen on
 //!    let listen_config = ListenConfig::Ipv4 {
 //!        ip: Ipv4Addr::UNSPECIFIED,
 //!        port: 9000,
 //!    };
 //!
+//!    // default configuration
+//!    let config = Discv5ConfigBuilder::new(listen_config).build();
+//!
 //!    // construct the discv5 server
-//!    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
+//!    let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
 //!
 //!    // In order to bootstrap the routing table an external ENR should be added
 //!    // This can be done via add_enr. I.e.:

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 
-use crate::socket::ListenConfig;
 use crate::{
     handler::Handler,
     kbucket,
@@ -12,6 +11,7 @@ use crate::{
     query_pool::{QueryId, QueryPool},
     rpc::RequestId,
     service::{ActiveRequest, Service},
+    socket::ListenConfig,
     Discv5ConfigBuilder, Enr,
 };
 use enr::{CombinedKey, EnrBuilder};

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -27,7 +27,7 @@ pub use recv::InboundPacket;
 pub use send::OutboundPacket;
 
 /// Configuration for the sockets to listen on.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ListenConfig {
     Ipv4 {
         ip: Ipv4Addr,


### PR DESCRIPTION
ref: https://github.com/sigp/discv5/pull/160#discussion_r1159181642

Before
```rust
// builder
let config = Discv5ConfigBuilder::default().build();
// default configuration
// let config = Dicv5Config::default();

let listen_config = ListenConfig { ... (omitted)... }

let mut discv5: Discv5 = Discv5::new(enr, enr_key, config, listen_config).unwrap();
```

After
- `Discv5ConfigBuilder::new()` requires `listen_config` since `ListenConfig` is not optional.
- `Discv5` and `Discv5ConfigBuilder` no longer implement `Default` since we can not determine the default value for  `ListenConfig`.
```rust
let listen_config = ListenConfig { ... (omitted)... }
let config = Discv5ConfigBuilder::new(listen_config).build();

let mut discv5: Discv5 = Discv5::new(enr, enr_key, config).unwrap();
```